### PR TITLE
Fix: Update GST breakdown heading to h4 for consistency

### DIFF
--- a/app.py
+++ b/app.py
@@ -417,7 +417,7 @@ def main():
                         
                         # GST Breakdown Table by Stock
                         st.markdown("""
-                        <h5 style="color: #0f172a; margin: 1rem 0; font-weight: 700;">GST Breakdown by Stock</h5>
+                        <h4 style="color: #0f172a; margin: 1rem 0; font-weight: 700;">GST Breakdown by Stock</h4>
                         """)
                         
                         # Create GST breakdown by stock


### PR DESCRIPTION
The heading for 'GST Breakdown by Stock' was using an h5 tag, which was inconsistent with other headings in the section that use h4. This change updates the heading to an h4 tag to improve visual consistency and semantic correctness.