### PR TITLE
Fix: Remove GST breakdown heading

### DIFF
--- a/app.py
+++ b/app.py
@@ -415,10 +415,6 @@ def main():
                         
                         st.markdown("<br>", unsafe_allow_html=True)
                         
-                        # GST Breakdown Table by Stock
-                        st.markdown("""
-                        <h4 style="color: #0f172a; margin: 1rem 0; font-weight: 700;">GST Breakdown by Stock</h4>
-                        """)
                         
                         # Create GST breakdown by stock
                         gst_breakdown = results_df.groupby('Stock').agg({


### PR DESCRIPTION
Removes the 'GST Breakdown by Stock' heading from the GST Calculator tab, as requested by the user. The heading was redundant and the user requested its removal.